### PR TITLE
Update Laravel version support in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "subfission/cas",
-  "description": "Adds CAS support to Laravel 5.x - 11.x",
+  "description": "Adds CAS support to Laravel 5.x - 12.x",
   "keywords": [
     "CAS",
     "phpCAS",
@@ -11,24 +11,29 @@
     "laravel 8",
     "laravel 9",
     "laravel 10",
-    "laravel 11"
+    "laravel 11",
+    "laravel 12"
   ],
   "license": "MIT",
   "authors": [
     {
       "name": "subfission",
       "role": "Developer"
+    },
+    {
+      "name": "MDSDTech",
+      "role": "Maintainer"
     }
   ],
   "require": {
     "php": ">=7.2.0",
-    "illuminate/support": "^6.0|^7.0|^8.0|^9.0|^10.0|^11.0",
+    "illuminate/support": "^6.0|^7.0|^8.0|^9.0|^10.0|^11.0|^12.0",
     "apereo/phpcas": "^1.6",
     "monolog/monolog": "^2.0|^3.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^8.0|^9.0|^10.0",
-    "pestphp/pest": "^1.21"
+    "phpunit/phpunit": "^8.0|^9.0|^10.0|^11.0",
+    "pestphp/pest": "^1.21|^3.0"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
This pull request updates the `composer.json` file to add support for Laravel 12 and modernize package dependencies. The changes ensure compatibility with the latest Laravel version and improve the package's maintenance and testing setup.

Laravel 12 support and dependency updates:

* Updated the package description and keywords to indicate support for Laravel 12. [[1]](diffhunk://#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34L3-R3) [[2]](diffhunk://#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34L14-R36)
* Extended the `illuminate/support` dependency to include compatibility with Laravel 12.x.

Maintenance and testing improvements:

* Added "MDSDTech" as a maintainer in the `authors` section.
* Updated `phpunit/phpunit` and `pestphp/pest` development dependencies to support their latest major versions.