### PR TITLE
Merge pull from main

### DIFF
--- a/.github/workflows/run-lint.yml
+++ b/.github/workflows/run-lint.yml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        php: [7.4, 8.2]
+        php: [7.4, 8.2, 8.3]
 
     name: PHP${{ matrix.php }}
 


### PR DESCRIPTION
This pull request makes a minor update to the PHP lint workflow configuration. The change expands the PHP version matrix to include PHP 8.3, ensuring that linting is run against the latest PHP release.

* Added PHP 8.3 to the `php` version matrix in `.github/workflows/run-lint.yml` to improve compatibility testing.