### PR TITLE
Merge Upcoming into main

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        php: [8.2, 8.1, 7.4, 7.3]
+        php: [8.3, 8.2, 8.1, 7.4, 7.3]
 
     name: PHP${{ matrix.php }}
 


### PR DESCRIPTION
This pull request updates the PHP version matrix in the GitHub Actions workflow to include PHP 8.3, ensuring that tests run on the latest PHP release.

* CI configuration update:
  * [`.github/workflows/run-tests.yml`](diffhunk://#diff-7314d0ebbd2e9537ae4889316745b4fd2fa43cb86275c9caae18a86ba228b642L11-R11): Added PHP 8.3 to the test matrix to improve compatibility and catch issues with the newest PHP version.